### PR TITLE
Slent fixm 248

### DIFF
--- a/docs/fixm-in-support-of-ffice/ffice-application-for-fixm.md
+++ b/docs/fixm-in-support-of-ffice/ffice-application-for-fixm.md
@@ -26,10 +26,10 @@ Application include:
   possible types of FF-ICE Messages: Filed Flight Plan message,
   Submission Response message, Filing Status message etc.
 
-- Model elements representing the different FF-ICE statuses with their
-    possible values: Planning statuses `CONCUR` / `NON_CONCUR` / `NEGOTIATE`,
-    Filing statuses `ACCEPTABLE` / `NOT_ACCEPTABLE`, Submission statuses
-    `ACK` / `MANUAL` / `REJECT` etc.
+- Model elements representing the different FF-ICE statuses with their possible values: 
+    - Planning statuses: `CONCUR` / `NEGOTIATE` / `NON_CONCUR`
+    - Filing statuses: `ACCEPTABLE` / `NOT_ACCEPTABLE` / `PENDING` 
+    - Submission statuses: `ACK` / `MAN` / `REJ`
 
 - Model elements representing the FF-ICE participants and their
     properties, which are used for identifying the operational

--- a/docs/general-guidance/extensions.md
+++ b/docs/general-guidance/extensions.md
@@ -21,11 +21,7 @@ Examples:
 A number of rules are established in order to ensure that extensions are
 not developed as a replacement of FIXM Core or a subset thereof.
 
-The requirements on FIXM extensions are provided below. They are equally
-applicable to verified and non-verified extensions, but are enforceable
-only for verified extension. Non-verified extensions satisfying the
-requirements below will be recognised as a valid usage of the FIXM
-extension mechanism.
+The requirements on FIXM extensions are provided below.
 
 -----
 

--- a/docs/general-guidance/general-rules-for-data-correctness.md
+++ b/docs/general-guidance/general-rules-for-data-correctness.md
@@ -62,10 +62,6 @@ provide, may be a candidate means to enforce the business rules below.
 <td>The earliest time shall always be before the latest time.</td>
 </tr>
 <tr class="odd">
-<td>Aircraft</td>
-<td>The property formationCount, if provided, shall be equal to or greater than 2.</td>
-</tr>
-<tr class="odd">
 <td>OnlineContact</td>
 <td>The OnlineContact.network shall be always populated when providing an OnlineContact.linkage.</td>
 </tr>


### PR DESCRIPTION
This pull request is intended to address these issues from FIXM-248:

2. [*https://docs.fixm.aero/#/general-guidance/extensions*](https://github.com/fixm-ccb/fixm-user-manual-4.3.0-testing/compare/slent_FIXM_248?expand=1#/general-guidance/extensions*)
•	What is a valid use still mentions verified vs unverified extensions. I think we’ve gotten rid of this concept. Update this section appropriately.

3. [*https://docs.fixm.aero/#/general-guidance/general-rules-for-data-correctness*](https://github.com/fixm-ccb/fixm-user-manual-4.3.0-testing/compare/slent_FIXM_248?expand=1#/general-guidance/general-rules-for-dat)
•	Remove entry for Aircraft (since formationCount is gone).

5. [*https://docs.fixm.aero/#/fixm-in-support-of-ffice/ffice-application-for-fixm*](https://github.com/fixm-ccb/fixm-user-manual-4.3.0-testing/compare/slent_FIXM_248?expand=1#/fixm-in-support-of-ffice/ffice-applica)
•	Update list of status values under data structures (missing PENDING for filing status and submission status values MAN and REJ have been abbreviated) including bullet entry and diagram.
