### PR TITLE
 slent_using_FlightPlanOriginator_for_AFILs

### DIFF
--- a/docs/fixm-in-support-of-ffice/translating-ffice-fixm-messages-to-ats-messages.md
+++ b/docs/fixm-in-support-of-ffice/translating-ffice-fixm-messages-to-ats-messages.md
@@ -863,25 +863,17 @@ name then `referencePoint` in order of preference for creating 18 TALT.
 
 #### Air Filed
 
-When a flight plan is filed in the air, the value AFIL is inserted in
-field 13a and the ATS unit from which supplementary flight plan
-information can be obtained is specified in field 18 DEP. The mapping
-employs the attribute `supplementaryInformation` of class `Flight` for this
-purpose. In this situation the following rules should
-be applied:
+When a flight plan is filed in the air, the value AFIL is inserted in field 13a and the ATS unit from which supplementary flight plan information can be obtained is specified in field 18 DEP. When creating a FIXM object from an ATS message, the following rules should be applied:
 
--   Populate either the `locationIndicator` or `atcUnitNameOrAlternate` attribute of `unit`, which is an attribute of `supplementaryInformationSourceChoice`, which is in turn an association of `supplementaryInformation`, with the contents of field 18 DEP.
+-   Populate either the `locationIndicator` or `atcUnitNameOrAlternate` attribute (whichever is appropriate given the information provided) under `Flight.supplementaryInformation.supplementaryInformationSource.unit` with the contents of field 18 DEP.
 
--   Populate the attribute `airfileIndicator` of class `Departure` (with the constant
-    value AIRFILE).
+-   Populate `Flight.departure.airfileIndicator` with the constant value AIRFILE.
 
--   Populate the attribute `estimatedRouteStartTime` of
-    class `Departure` in
-    package `Flight.Departure` with the
-    content of field 13b.
+-   Populate `Flight.departure.estimatedRouteStartTime` with the time provided in field 13b.
 
--   The departure aerodrome (`aerodrome`) and departure time
-    (`estimatedOffBlockTime`) of class `Departure` are not populated.
+-   Populate the relevant option under `Flight.departure.departurePoint` with the first significant point in the route (if available).
+
+When creating an ATS message from a FIXM object, the presence of AIRFILE under `Flight.departure.airfileIndicator` will indicate the need to place AFIL in field 13a.  Extract the other needed information from the FIXM fields specified above to populate fields 13b and 18 DEP.
 
 The image below presents the FIXM representation of the following air
 filed flight plan (fragment) as an object model.

--- a/docs/fixm-in-support-of-ffice/translating-ffice-fixm-messages-to-ats-messages.md
+++ b/docs/fixm-in-support-of-ffice/translating-ffice-fixm-messages-to-ats-messages.md
@@ -870,7 +870,7 @@ employs the attribute `supplementaryInformation` of class `Flight` for this
 purpose. In this situation the following rules should
 be applied:
 
--   Populate either the `locationIndicator` or `atcUnitNameOrAlternate` attribute of `unit`, which is an attritbute of `supplementaryInformationSourceChoice`, which is in turn an association of 'supplementaryInformation', with the contents of field 18 DEP.
+-   Populate either the `locationIndicator` or `atcUnitNameOrAlternate` attribute of `unit`, which is an attritbute of `supplementaryInformationSourceChoice`, which is in turn an association of `supplementaryInformation`, with the contents of field 18 DEP.
 
 -   Populate the attribute `airfileIndicator` of class `Departure` (with the constant
     value AIRFILE).

--- a/docs/fixm-in-support-of-ffice/translating-ffice-fixm-messages-to-ats-messages.md
+++ b/docs/fixm-in-support-of-ffice/translating-ffice-fixm-messages-to-ats-messages.md
@@ -876,7 +876,7 @@ be applied:
 -   Populate the `airfileIndicator` of class `Departure` (with the constant
     value AIRFILE).
 
--   Populate `airfileRouteStartTime` of
+-   Populate the element `airfileRouteStartTime` of
     class `FlightRouteInformation` in
     package `Flight.FlightRouteTrajectory.RouteTrajectory` with the
     content of field 13b.

--- a/docs/fixm-in-support-of-ffice/translating-ffice-fixm-messages-to-ats-messages.md
+++ b/docs/fixm-in-support-of-ffice/translating-ffice-fixm-messages-to-ats-messages.md
@@ -870,8 +870,7 @@ employs the attribute `supplementaryInformation` of class `Flight` for this
 purpose. In this situation the following rules should
 be applied:
 
--   Populate the attribute `unit` of `supplementaryInformationSource` (via
-    the `supplementaryInformation` attribute) with the content of field 18 DEP.
+-   Populate either the `locationIndicator` or `atcUnitNameOrAlternate` attribute of `unit`, which is an attritbute of `supplementaryInformationSourceChoice`, which is in turn an association of 'supplementaryInformation', with the contents of field 18 DEP.
 
 -   Populate the attribute `airfileIndicator` of class `Departure` (with the constant
     value AIRFILE).

--- a/docs/fixm-in-support-of-ffice/translating-ffice-fixm-messages-to-ats-messages.md
+++ b/docs/fixm-in-support-of-ffice/translating-ffice-fixm-messages-to-ats-messages.md
@@ -870,7 +870,7 @@ employs the attribute `supplementaryInformation` of class `Flight` for this
 purpose. In this situation the following rules should
 be applied:
 
--   Populate either the `locationIndicator` or `atcUnitNameOrAlternate` attribute of `unit`, which is an attritbute of `supplementaryInformationSourceChoice`, which is in turn an association of `supplementaryInformation`, with the contents of field 18 DEP.
+-   Populate either the `locationIndicator` or `atcUnitNameOrAlternate` attribute of `unit`, which is an attribute of `supplementaryInformationSourceChoice`, which is in turn an association of `supplementaryInformation`, with the contents of field 18 DEP.
 
 -   Populate the attribute `airfileIndicator` of class `Departure` (with the constant
     value AIRFILE).

--- a/docs/fixm-in-support-of-ffice/translating-ffice-fixm-messages-to-ats-messages.md
+++ b/docs/fixm-in-support-of-ffice/translating-ffice-fixm-messages-to-ats-messages.md
@@ -870,7 +870,7 @@ employs the attribute `supplementaryInformation` of class `Flight` for this
 purpose. In this situation the following rules should
 be applied:
 
--   Populate the either the `personOrOrganization` or `unit` attribute of `supplementaryInformationSource` (via
+-   Populate the attribute `unit` of `supplementaryInformationSource` (via
     the `supplementaryInformation` attribute) with the content of field 18 DEP.
 
 -   Populate the attribute `airfileIndicator` of class `Departure` (with the constant

--- a/docs/fixm-in-support-of-ffice/translating-ffice-fixm-messages-to-ats-messages.md
+++ b/docs/fixm-in-support-of-ffice/translating-ffice-fixm-messages-to-ats-messages.md
@@ -866,19 +866,19 @@ name then `referencePoint` in order of preference for creating 18 TALT.
 When a flight plan is filed in the air, the value AFIL is inserted in
 field 13a and the ATS unit from which supplementary flight plan
 information can be obtained is specified in field 18 DEP. The mapping
-employs the element `flightPlanOriginator` of class `Flight` for this
+employs the attribute `supplementaryInformation` of class `Flight` for this
 purpose. In this situation the following rules should
 be applied:
 
--   Populate the name element of `PersonOrOrganization` (via
-    element `flightPlanSubmitter`) with the content of field 18 DEP.
+-   Populate the either the `personOrOrganization` or `unit` attribute of `supplementaryInformationSource` (via
+    the `supplementaryInformation` attribute) with the content of field 18 DEP.
 
--   Populate the `airfileIndicator` of class `Departure` (with the constant
+-   Populate the attribute `airfileIndicator` of class `Departure` (with the constant
     value AIRFILE).
 
--   Populate the element `airfileRouteStartTime` of
-    class `FlightRouteInformation` in
-    package `Flight.FlightRouteTrajectory.RouteTrajectory` with the
+-   Populate the attribute `estimatedRouteStartTime` of
+    class `Departure` in
+    package `Flight.Departure` with the
     content of field 13b.
 
 -   The departure aerodrome (`aerodrome`) and departure time

--- a/docs/fixm-in-support-of-ffice/translating-ffice-fixm-messages-to-ats-messages.md
+++ b/docs/fixm-in-support-of-ffice/translating-ffice-fixm-messages-to-ats-messages.md
@@ -866,18 +866,17 @@ name then `referencePoint` in order of preference for creating 18 TALT.
 When a flight plan is filed in the air, the value AFIL is inserted in
 field 13a and the ATS unit from which supplementary flight plan
 information can be obtained is specified in field 18 DEP. The mapping
-employs the attribute `flightPlanSubmitter` of class `Flight` for this
-purpose, though the name is not immediately suggestive of the purpose
-for which it is being used. In this situation the following rules should
+employs the element `flightPlanOriginator` of class `Flight` for this
+purpose. In this situation the following rules should
 be applied:
 
--   Populate the name attribute of `PersonOrOrganization` (via
-    attribute `flightPlanSubmitter`) with the content of field 18 DEP.
+-   Populate the name element of `PersonOrOrganization` (via
+    element `flightPlanSubmitter`) with the content of field 18 DEP.
 
 -   Populate the `airfileIndicator` of class `Departure` (with the constant
     value AIRFILE).
 
--   Populate the attribute `airfileRouteStartTime` of
+-   Populate `airfileRouteStartTime` of
     class `FlightRouteInformation` in
     package `Flight.FlightRouteTrajectory.RouteTrajectory` with the
     content of field 13b.


### PR DESCRIPTION
This pull request does two things:

1) It changes the guidance to use FlightPlanOriginator instead of FlightPlanSubmitter for "the ATS unit from which
supplementary flight plan data can be obtained" that is stored in Field 18 DEP/ for airfiles.
2) It updates a few references to "attribute" to "element" in the guidance.