### PR TITLE
Update flight_capabilities.md

### DIFF
--- a/docs/general-guidance/flight_capabilities.md
+++ b/docs/general-guidance/flight_capabilities.md
@@ -20,3 +20,25 @@ Examples of encoding:
 <!--xmlns:fx="http://www.fixm.aero/flight/4.3"-->
 <fx:selectiveCallingCode>GQE8</fx:selectiveCallingCode>
 ```
+
+#### Compatibility with FIXM Core 4.2.0
+
+FIXM Core 4.2.0 was released before the publication of Amendment 91 to ICAO Annex 10 Volume III and therefore does not natively support the new letters from T to Z and the numbers 1 to 9 added to the SELCAL standard. However, forward and backward compatibility between 4.2.0 and 4.3.0 is ensured:
+
+*`FIXM Core 4.2.0` -> `FIXM Core 4.3.0`*
+- A `SELCAL Code` that can be encoded in `FIXM Core 4.2.0` can be natively encoded in `FIXM Core 4.3.0`, using property `fx:selectiveCallingCode`
+
+
+*`FIXM Core 4.3.0` -> `FIXM Core 4.2.0`*
+- A `SELCAL Code` that can be encoded in `FIXM Core 4.3.0` and which does not include any letter from T to Z and/or numbers from 1 to 9 can be natively encoded in `FIXM Core 4.2.0`, using property `fx:selectiveCallingCode`
+- A `SELCAL Code` that can be encoded in `FIXM Core 4.3.0`and  which includes at least one letter from T to Z and/or a number from 1 to 9 can be encoded in `FIXM Core 4.2.0` using this workaround involving property `fx:otherCommunicationCapabilities`
+```xml
+<!-- FF-ICE Flight Plan filed in old 4.2.0 format...-->
+<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+<!-- xmlns:fx="http://www.fixm.aero/flight/4.2" -->
+<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+<fx:capabilities>
+  <fx:communication>
+   <fx:otherCommunicationCapabilities>selectiveCallingCode=ABC3</...>  
+<!-- USE ";" as separator if the property fx:otherCommunicationCapabilities contains additional information -->
+```


### PR DESCRIPTION
Add 4.3.0-4.2.0 compatibility considerations about SELCAL codes. 
Document a workaround for accommodating new SELCAL codes in FIXM 4.2.0 (based on NM B2B experience with 4.2.0)