### PR TITLE
Update vertical-distances.md

### DIFF
--- a/docs/general-guidance/vertical-distances.md
+++ b/docs/general-guidance/vertical-distances.md
@@ -2,9 +2,8 @@
 
 ## Definitions
 
-The term vertical distance collectively refers to altitudes, elevations
-and heights, as defined by
-ICAO
+The term vertical distance collectively refers to altitudes, elevations,
+and heights, as defined by ICAO
 
 ![Image](.//media/general-guidance-vertical-distances-01.png "Differences between Elevation, Altitude, Height and Ellipsoid height")
 
@@ -29,21 +28,22 @@ ICAO
 FIXM supports the representation of altitudes expressed in feet or
 meters (FIXM construct `Altitude`), of altitudes expressed as flight
 level number or standard metric level (FIXM construct `FlightLevel`) and
-of ellipsoid heights & heights SFC expressed in feet or meter (FIXM
+of ellipsoid heights & SFC heights expressed in feet or meters (FIXM
 construct `Height` used in conjunction with a `VerticalReference`).
 
-![Image](.//media/image23.png ':size=125%')
+![Image](.//media/image23.png ':size=75%')
 
 These vertical distances are specialisations of the generic class
 `Measure` which serves as the parent class for all measure types including
-speeds, angles, pressures, temperatures etc. Therefore, altitudes,
-flight levels and heights are always encoded as double values, although
-integer values are expected.<sup>[[note 1]](#notes)</sup>
+speeds, angles, pressures, temperatures, etc. Therefore, altitudes, flight 
+levels, and heights are encoded as decimal fields, although integer values 
+are typically expected. Flight levels go through an extra layer of 
+restriction (via class `RestrictedVerticalDistance`) to ensure they are 
+always represented with integer values.
 
 ### Examples
 
-#### The following examples show valid FIXM encoding of altitudes and flight
-levels expressed as integer.
+#### The following examples show altitudes expressed with integers values.  
 
 ```xml
 <fb:altitude uom="FT">10000</fb:altitude>
@@ -53,29 +53,8 @@ levels expressed as integer.
 <fb:altitude uom="M">3500</fb:altitude>
 ```
 
-```xml
-<fb:flightLevel uom="FL">290</fb:flightLevel>
-```
+#### The following example shows an altitude expressed with a decimal value. This encoding is technically permitted by FIXM but is NOT RECOMMENDED.
 
 ```xml
-<fb:flightLevel uom="SM">1130</fb:flightLevel>
+<fb:altitude uom="M">3500.1</fb:altitude>
 ```
-
-#### The following example shows the encoding of a flight level expressed as
-a double. This encoding is technically permitted by FIXM but is NOT
-RECOMMENDED.
-
-```xml
-<fb:flightLevel uom="FL">290.0</fb:flightLevel>
-```
-
-## Notes
-
-[1]: “Double Integer” conversion can be handled
-differently depending on the technical context. This may lead to e.g.
-flight level value 100 being expressed as 100.00…0001 and the flight
-level value 101 being expressed as 100.99…99999. It is acknowledged that
-the current FIXM design may create value persistence problem across
-applications, in particular if rounding or truncation are applied
-further down. FIXM implementers are therefore invited to verify the
-persistence of vertical distances values across their software.


### PR DESCRIPTION
Fixed examples and explanation based on changes in 4.3.  Removed note as it no longer applies to decimal elements.